### PR TITLE
Support for lumen 5.5+

### DIFF
--- a/src/Providers/HealthServiceProvider.php
+++ b/src/Providers/HealthServiceProvider.php
@@ -23,7 +23,20 @@ class HealthServiceProvider extends ServiceProvider
 
     public function boot()
     {
-        $this->app->get('health', '\Filld\Health\Controllers\HealthController@index');
+        $router = $this->app;
+
+        preg_match('/\(\d\.\d\.\d\)/', app()->version(), $matches);
+
+        if (!empty($matches[0]))
+        {
+            $version = intval(str_replace(['.', '(', ')'], '', $matches[0]));
+            if ($version > 550)
+            {
+                $router = $this->app->router;
+            }
+        }
+
+        $router->get('health', '\Filld\Health\Controllers\HealthController@index');
     }
 
 


### PR DESCRIPTION
As per upgrade guide, the router now is in different place: https://lumen.laravel.com/docs/5.5/upgrade#upgrade-5.5.0

The PR gets the version of the lumen and depending on it returns correct route for health callback